### PR TITLE
删去事件中未使用的 potions.IPotion 和 potions.IPotionEffect 包

### DIFF
--- a/events/restriction-endoflame.md
+++ b/events/restriction-endoflame.md
@@ -53,8 +53,6 @@ import crafttweaker.block.IBlock;
 import crafttweaker.world.IBlockPos;
 import crafttweaker.player.IPlayer;
 import crafttweaker.data.IData;
-import crafttweaker.potions.IPotion;
-import crafttweaker.potions.IPotionEffect;
 
 import mods.ctutils.utils.Math;
 


### PR DESCRIPTION
通读了事件代码和流程图，发现在代码中并未使用这两个包的任何变量或方法。
考虑到教程示例代码应当尽量避免冗余，以避免干扰读者判断，
在此将这两个包导入语句删去。